### PR TITLE
Add support for `strat` `down:test` script

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -80,6 +80,9 @@ const (
 
 	// TestScript is the name of the project test script.
 	TestScript = "test"
+
+	// DownTestScript is the name of the project down script for test.
+	DownTestScript = "test:down"
 )
 
 const win = "windows"

--- a/cli/test.go
+++ b/cli/test.go
@@ -54,5 +54,12 @@ func (cmd *Test) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 		return subcommands.ExitUsageError
 	}
 
-	return runScript(TestScript, "", false)
+	testRes := runScript(TestScript, "", false)
+	downRes := runScript(DownTestScript, "", true)
+
+	if testRes != subcommands.ExitSuccess {
+		return testRes
+	}
+
+	return downRes
 }


### PR DESCRIPTION
Tests often need to run a command to clean up (like `docker-compose down`)
after the tests run, even after if the tests fail. Currently it is
possible, but it is tedious to return the tests exit code properly.

This commit makes `strat test` execute a `down:test` script if present
after the tests. It will handle the exit code properly.