### PR TITLE
Allow `strat` scripts to accept extra arguments

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -16,7 +16,6 @@ package cli
 
 import (
 	"flag"
-	"fmt"
 
 	"github.com/google/subcommands"
 	"golang.org/x/net/context"
@@ -38,7 +37,7 @@ func (*Build) Synopsis() string {
 
 // Usage implements github.com/google/subcommands.Command.Usage().
 func (*Build) Usage() string {
-	return `build:
+	return `build [args...]:
   Run build script.
 `
 }
@@ -49,10 +48,5 @@ func (*Build) SetFlags(f *flag.FlagSet) {
 
 // Execute implements github.com/google/subcommands.Command.Execute().
 func (cmd *Build) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	if len(f.Args()) > 0 {
-		fmt.Println(cmd.Usage())
-		return subcommands.ExitUsageError
-	}
-
-	return runScript(BuildScript, "", false)
+	return runScript(BuildScript, "", f.Args(), false)
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -23,6 +23,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 
 	"github.com/google/subcommands"
@@ -145,7 +146,7 @@ func varsPath() (string, error) {
 	return filepath.Join(homeDir, StratumnDir, VarsFile), nil
 }
 
-func runScript(name, wd string, ignoreNotExist bool) subcommands.ExitStatus {
+func runScript(name, wd string, args []string, ignoreNotExist bool) subcommands.ExitStatus {
 	prj, err := NewProjectFromFile(filepath.Join(wd, ProjectFile))
 	if err != nil {
 		fmt.Println(err)
@@ -169,6 +170,10 @@ func runScript(name, wd string, ignoreNotExist bool) subcommands.ExitStatus {
 		}
 		fmt.Printf("Project doesn't have a %q script.\n", name)
 		return subcommands.ExitFailure
+	}
+
+	if len(args) > 0 {
+		script += " " + strings.Join(args, " ")
 	}
 
 	var shell []string

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -168,7 +168,7 @@ func (cmd *Generate) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 		return subcommands.ExitFailure
 	}
 
-	if err := runScript(InitScript, out, true); err != subcommands.ExitSuccess {
+	if err := runScript(InitScript, out, nil, true); err != subcommands.ExitSuccess {
 		fmt.Println(err)
 		return err
 	}

--- a/cli/run.go
+++ b/cli/run.go
@@ -38,7 +38,7 @@ func (*Run) Synopsis() string {
 
 // Usage implements github.com/google/subcommands.Command.Usage().
 func (*Run) Usage() string {
-	return `run script:
+	return `run script [args...]:
   Run script by name.
 `
 }
@@ -51,10 +51,10 @@ func (*Run) SetFlags(f *flag.FlagSet) {
 func (cmd *Run) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	args := f.Args()
 
-	if len(args) != 1 {
+	if len(args) < 1 {
 		fmt.Println(cmd.Usage())
 		return subcommands.ExitUsageError
 	}
 
-	return runScript(args[0], "", false)
+	return runScript(args[0], "", args[1:], false)
 }

--- a/cli/test.go
+++ b/cli/test.go
@@ -16,7 +16,6 @@ package cli
 
 import (
 	"flag"
-	"fmt"
 
 	"github.com/google/subcommands"
 	"golang.org/x/net/context"
@@ -38,7 +37,7 @@ func (*Test) Synopsis() string {
 
 // Usage implements github.com/google/subcommands.Command.Usage().
 func (*Test) Usage() string {
-	return `test:
+	return `test [args...]:
   Run tests.
 `
 }
@@ -49,13 +48,8 @@ func (*Test) SetFlags(f *flag.FlagSet) {
 
 // Execute implements github.com/google/subcommands.Command.Execute().
 func (cmd *Test) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	if len(f.Args()) > 0 {
-		fmt.Println(cmd.Usage())
-		return subcommands.ExitUsageError
-	}
-
-	testRes := runScript(TestScript, "", false)
-	downRes := runScript(DownTestScript, "", true)
+	testRes := runScript(TestScript, "", f.Args(), false)
+	downRes := runScript(DownTestScript, "", nil, true)
 
 	if testRes != subcommands.ExitSuccess {
 		return testRes

--- a/cli/up.go
+++ b/cli/up.go
@@ -16,7 +16,6 @@ package cli
 
 import (
 	"flag"
-	"fmt"
 
 	"github.com/google/subcommands"
 	"golang.org/x/net/context"
@@ -38,7 +37,7 @@ func (*Up) Synopsis() string {
 
 // Usage implements github.com/google/subcommands.Command.Usage().
 func (*Up) Usage() string {
-	return `up:
+	return `up [args...]:
   Start services.
 `
 }
@@ -49,10 +48,5 @@ func (*Up) SetFlags(f *flag.FlagSet) {
 
 // Execute implements github.com/google/subcommands.Command.Execute().
 func (cmd *Up) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	if len(f.Args()) > 0 {
-		fmt.Println(cmd.Usage())
-		return subcommands.ExitUsageError
-	}
-
-	return runScript(UpScript, "", false)
+	return runScript(UpScript, "", f.Args(), false)
 }


### PR DESCRIPTION
This change makes it possible to pass arguments (both flags and
parameters) to a script when executing it.

For instance, you might do something like:

```
$ strat run script compose:dev ps -q
```

Both `ps` and `-q` will be appended to the script command.

However, due to flag parsing, if executing a builtin command, you have
to seperate script flags if there are no extra parameters provided.

For instance:

```
$ strat run up -d
```

will not work because `strat` will try to parse the flag. You can work
around this issue by doing instead:

```
$ strat run up -- -d
```