### PR TITLE
Add `strat deploy` command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -101,6 +101,10 @@ const (
 	// PushScript is the name of the project push script.
 	PushScript = "push"
 
+	// DeployScriptFmt is the format of the name of the project deploy
+	// script for an environment.
+	DeployScriptFmt = "deploy:%s"
+
 	// DownTestScript is the name of the project down script for test.
 	DownTestScript = "down:test"
 )

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -16,37 +16,47 @@ package cli
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/google/subcommands"
 	"golang.org/x/net/context"
 )
 
-// Build is a project command that builds the project.
-type Build struct {
+// Deploy is a project command that deploys a project to an environment.
+type Deploy struct {
 }
 
 // Name implements github.com/google/subcommands.Command.Name().
-func (*Build) Name() string {
-	return "build"
+func (*Deploy) Name() string {
+	return "deploy"
 }
 
 // Synopsis implements github.com/google/subcommands.Command.Synopsis().
-func (*Build) Synopsis() string {
-	return "build project"
+func (*Deploy) Synopsis() string {
+	return "deploy project to an environment"
 }
 
 // Usage implements github.com/google/subcommands.Command.Usage().
-func (*Build) Usage() string {
-	return `build [args...]:
-  Build project.
+func (*Deploy) Usage() string {
+	return `deploy environment [args...]:
+  Deploy project to given environment.
 `
 }
 
 // SetFlags implements github.com/google/subcommands.Command.SetFlags().
-func (*Build) SetFlags(f *flag.FlagSet) {
+func (*Deploy) SetFlags(f *flag.FlagSet) {
 }
 
 // Execute implements github.com/google/subcommands.Command.Execute().
-func (cmd *Build) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	return runScript(BuildScript, "", f.Args(), false)
+func (cmd *Deploy) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	args := f.Args()
+
+	if len(args) < 1 {
+		fmt.Println(cmd.Usage())
+		return subcommands.ExitUsageError
+	}
+
+	script := fmt.Sprintf(DeployScriptFmt, args[0])
+
+	return runScript(script, "", args[1:], false)
 }

--- a/cmd/strat/doc.go
+++ b/cmd/strat/doc.go
@@ -32,7 +32,8 @@
 //		help             describe subcommands and their syntax
 //
 //	Subcommands for project:
-//		build            run build script
+//		build            build project
+//		deploy           deploy project to an environment
 //		down             stop services
 //		pull             pull updates
 //		push             push updates

--- a/cmd/strat/main.go
+++ b/cmd/strat/main.go
@@ -42,6 +42,7 @@ func main() {
 	subcommands.Register(&cli.Push{}, "project")
 	subcommands.Register(&cli.Pull{}, "project")
 	subcommands.Register(&cli.Run{}, "project")
+	subcommands.Register(&cli.Deploy{}, "project")
 	subcommands.Register(&cli.Update{Version: version}, "CLI")
 	subcommands.Register(&cli.Info{Version: version, Commit: commit}, "CLI")
 	subcommands.Register(&cli.Version{Version: version, Commit: commit}, "CLI")


### PR DESCRIPTION
The command expects an environment name as the first argument. It will
try to execute the `deploy:{env}` script of the project.