### PR TITLE
Add `-stdin` flag to script runners

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -23,6 +23,7 @@ import (
 
 // Build is a project command that builds the project.
 type Build struct {
+	stdin bool
 }
 
 // Name implements github.com/google/subcommands.Command.Name().
@@ -43,10 +44,11 @@ func (*Build) Usage() string {
 }
 
 // SetFlags implements github.com/google/subcommands.Command.SetFlags().
-func (*Build) SetFlags(f *flag.FlagSet) {
+func (cmd *Build) SetFlags(f *flag.FlagSet) {
+	f.BoolVar(&cmd.stdin, "stdin", false, "attach stdin to command")
 }
 
 // Execute implements github.com/google/subcommands.Command.Execute().
 func (cmd *Build) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	return runScript(BuildScript, "", f.Args(), false)
+	return runScript(BuildScript, "", f.Args(), false, cmd.stdin)
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -189,7 +189,7 @@ func varsPath() (string, error) {
 	return filepath.Join(config, VarsFile), nil
 }
 
-func runScript(name, wd string, args []string, ignoreNotExist bool) subcommands.ExitStatus {
+func runScript(name, wd string, args []string, ignoreNotExist, stdin bool) subcommands.ExitStatus {
 	prj, err := NewProjectFromFile(filepath.Join(wd, ProjectFile))
 	if err != nil {
 		fmt.Println(err)
@@ -231,7 +231,10 @@ func runScript(name, wd string, args []string, ignoreNotExist bool) subcommands.
 	c.Dir = wd
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
-	c.Stdin = os.Stdin
+
+	if stdin {
+		c.Stdin = os.Stdin
+	}
 
 	fmt.Printf("Running %q...\n", script)
 

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -24,6 +24,7 @@ import (
 
 // Deploy is a project command that deploys a project to an environment.
 type Deploy struct {
+	stdin bool
 }
 
 // Name implements github.com/google/subcommands.Command.Name().
@@ -44,7 +45,8 @@ func (*Deploy) Usage() string {
 }
 
 // SetFlags implements github.com/google/subcommands.Command.SetFlags().
-func (*Deploy) SetFlags(f *flag.FlagSet) {
+func (cmd *Deploy) SetFlags(f *flag.FlagSet) {
+	f.BoolVar(&cmd.stdin, "stdin", false, "attach stdin to command")
 }
 
 // Execute implements github.com/google/subcommands.Command.Execute().
@@ -58,5 +60,5 @@ func (cmd *Deploy) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{})
 
 	script := fmt.Sprintf(DeployScriptFmt, args[0])
 
-	return runScript(script, "", args[1:], false)
+	return runScript(script, "", args[1:], false, cmd.stdin)
 }

--- a/cli/down.go
+++ b/cli/down.go
@@ -23,6 +23,7 @@ import (
 
 // Down is a project command that stops the services.
 type Down struct {
+	stdin bool
 }
 
 // Name implements github.com/google/subcommands.Command.Name().
@@ -43,10 +44,11 @@ func (*Down) Usage() string {
 }
 
 // SetFlags implements github.com/google/subcommands.Command.SetFlags().
-func (*Down) SetFlags(f *flag.FlagSet) {
+func (cmd *Down) SetFlags(f *flag.FlagSet) {
+	f.BoolVar(&cmd.stdin, "stdin", false, "attach stdin to command")
 }
 
 // Execute implements github.com/google/subcommands.Command.Execute().
 func (cmd *Down) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	return runScript(DownScript, "", f.Args(), false)
+	return runScript(DownScript, "", f.Args(), false, cmd.stdin)
 }

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -37,6 +37,7 @@ type Generate struct {
 	ref     string
 	name    string
 	ghToken string
+	stdin   bool
 }
 
 // Name implements github.com/google/subcommands.Command.Name().
@@ -63,6 +64,7 @@ func (cmd *Generate) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&cmd.ref, "ref", DefaultGeneratorsRef, "Github branch, tag, or commit SHA1")
 	f.StringVar(&cmd.name, "name", "", "generator name")
 	f.StringVar(&cmd.ghToken, "ghtoken", "", "Github token for private repos")
+	f.BoolVar(&cmd.stdin, "stdin", false, "attach stdin to command")
 }
 
 // Execute implements github.com/google/subcommands.Command.Execute().
@@ -174,7 +176,7 @@ func (cmd *Generate) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 	}
 
 	if _, err := os.Stat(filepath.Join(out, ProjectFile)); err == nil {
-		if code := runScript(InitScript, out, nil, true); code != subcommands.ExitSuccess {
+		if code := runScript(InitScript, out, nil, true, cmd.stdin); code != subcommands.ExitSuccess {
 			return code
 		}
 	} else if !os.IsNotExist(err) {

--- a/cli/pull.go
+++ b/cli/pull.go
@@ -23,6 +23,7 @@ import (
 
 // Pull is a project command that pulls updates.
 type Pull struct {
+	stdin bool
 }
 
 // Name implements github.com/google/subcommands.Command.Name().
@@ -43,10 +44,11 @@ func (*Pull) Usage() string {
 }
 
 // SetFlags implements github.com/google/subcommands.Command.SetFlags().
-func (*Pull) SetFlags(f *flag.FlagSet) {
+func (cmd *Pull) SetFlags(f *flag.FlagSet) {
+	f.BoolVar(&cmd.stdin, "stdin", false, "attach stdin to command")
 }
 
 // Execute implements github.com/google/subcommands.Command.Execute().
 func (cmd *Pull) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	return runScript(PullScript, "", f.Args(), false)
+	return runScript(PullScript, "", f.Args(), false, cmd.stdin)
 }

--- a/cli/push.go
+++ b/cli/push.go
@@ -23,6 +23,7 @@ import (
 
 // Push is a project command that pushes updates.
 type Push struct {
+	stdin bool
 }
 
 // Name implements github.com/google/subcommands.Command.Name().
@@ -43,10 +44,11 @@ func (*Push) Usage() string {
 }
 
 // SetFlags implements github.com/google/subcommands.Command.SetFlags().
-func (*Push) SetFlags(f *flag.FlagSet) {
+func (cmd *Push) SetFlags(f *flag.FlagSet) {
+	f.BoolVar(&cmd.stdin, "stdin", false, "attach stdin to command")
 }
 
 // Execute implements github.com/google/subcommands.Command.Execute().
 func (cmd *Push) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	return runScript(PushScript, "", f.Args(), false)
+	return runScript(PushScript, "", f.Args(), false, cmd.stdin)
 }

--- a/cli/run.go
+++ b/cli/run.go
@@ -24,6 +24,7 @@ import (
 
 // Run is a project command that runs script by name.
 type Run struct {
+	stdin bool
 }
 
 // Name implements github.com/google/subcommands.Command.Name().
@@ -44,7 +45,8 @@ func (*Run) Usage() string {
 }
 
 // SetFlags implements github.com/google/subcommands.Command.SetFlags().
-func (*Run) SetFlags(f *flag.FlagSet) {
+func (cmd *Run) SetFlags(f *flag.FlagSet) {
+	f.BoolVar(&cmd.stdin, "stdin", false, "attach stdin to command")
 }
 
 // Execute implements github.com/google/subcommands.Command.Execute().
@@ -56,5 +58,5 @@ func (cmd *Run) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) su
 		return subcommands.ExitUsageError
 	}
 
-	return runScript(args[0], "", args[1:], false)
+	return runScript(args[0], "", args[1:], false, cmd.stdin)
 }

--- a/cli/test.go
+++ b/cli/test.go
@@ -23,6 +23,7 @@ import (
 
 // Test is a project command that runs tests.
 type Test struct {
+	stdin bool
 }
 
 // Name implements github.com/google/subcommands.Command.Name().
@@ -43,13 +44,14 @@ func (*Test) Usage() string {
 }
 
 // SetFlags implements github.com/google/subcommands.Command.SetFlags().
-func (*Test) SetFlags(f *flag.FlagSet) {
+func (cmd *Test) SetFlags(f *flag.FlagSet) {
+	f.BoolVar(&cmd.stdin, "stdin", false, "attach stdin to command")
 }
 
 // Execute implements github.com/google/subcommands.Command.Execute().
 func (cmd *Test) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	testRes := runScript(TestScript, "", f.Args(), false)
-	downRes := runScript(DownTestScript, "", nil, true)
+	testRes := runScript(TestScript, "", f.Args(), false, cmd.stdin)
+	downRes := runScript(DownTestScript, "", nil, true, cmd.stdin)
 
 	if testRes != subcommands.ExitSuccess {
 		return testRes

--- a/cli/up.go
+++ b/cli/up.go
@@ -23,6 +23,7 @@ import (
 
 // Up is a project command that starts the services.
 type Up struct {
+	stdin bool
 }
 
 // Name implements github.com/google/subcommands.Command.Name().
@@ -43,10 +44,11 @@ func (*Up) Usage() string {
 }
 
 // SetFlags implements github.com/google/subcommands.Command.SetFlags().
-func (*Up) SetFlags(f *flag.FlagSet) {
+func (cmd *Up) SetFlags(f *flag.FlagSet) {
+	f.BoolVar(&cmd.stdin, "stdin", false, "attach stdin to command")
 }
 
 // Execute implements github.com/google/subcommands.Command.Execute().
 func (cmd *Up) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	return runScript(UpScript, "", f.Args(), false)
+	return runScript(UpScript, "", f.Args(), false, cmd.stdin)
 }


### PR DESCRIPTION
This change adds a `-stdin` flag to all `strat` commands that execute
scripts. It is set to `false` by default. If true, the standard input will be
attached to the process executing the shell command.