### PR TITLE
Fix didSaveChans notification in TMStore

### DIFF
--- a/cmd/tmstore/doc.go
+++ b/cmd/tmstore/doc.go
@@ -20,6 +20,8 @@
 //	Usage of tmstore:
 //	  -endpoint string
 //     		endpoint used to communicate with Tendermint Core (default "tcp://127.0.0.1:46657")
+//	  -tmWsRetryInterval duration
+//		interval between tendermint websocket connection tries (default 5s)
 //	  -http string
 //	    	HTTP address (default ":5000")
 //	  -maxmsgsize int

--- a/cmd/tmstore/main.go
+++ b/cmd/tmstore/main.go
@@ -17,27 +17,31 @@ package main
 import (
 	"flag"
 
+	"time"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/stratumn/go/jsonhttp"
 	"github.com/stratumn/go/jsonws"
 	"github.com/stratumn/go/store/storehttp"
 	"github.com/stratumn/go/tmstore"
+	"github.com/stratumn/go/utils"
 )
 
 var (
-	http            = flag.String("http", storehttp.DefaultAddress, "HTTP address")
-	wsReadBufSize   = flag.Int("wsreadbufsize", storehttp.DefaultWebSocketReadBufferSize, "Web socket read buffer size")
-	wsWriteBufSize  = flag.Int("wswritebufsize", storehttp.DefaultWebSocketWriteBufferSize, "Web socket write buffer size")
-	wsWriteChanSize = flag.Int("wswritechansize", storehttp.DefaultWebSocketWriteChanSize, "Size of a web socket connection write channel")
-	wsWriteTimeout  = flag.Duration("wswritetimeout", storehttp.DefaultWebSocketWriteTimeout, "Timeout for a web socket write")
-	wsPongTimeout   = flag.Duration("wspongtimeout", storehttp.DefaultWebSocketPongTimeout, "Timeout for a web socket expected pong")
-	wsPingInterval  = flag.Duration("wspinginterval", storehttp.DefaultWebSocketPingInterval, "Interval between web socket pings")
-	wsMaxMsgSize    = flag.Int64("maxmsgsize", storehttp.DefaultWebSocketMaxMsgSize, "Maximum size of a received web socket message")
-	endpoint        = flag.String("endpoint", tmstore.DefaultEndpoint, "endpoint used to communicate with Tendermint Core")
-	certFile        = flag.String("tlscert", "", "TLS certificate file")
-	keyFile         = flag.String("tlskey", "", "TLS private key file")
-	version         = "0.1.0"
-	commit          = "00000000000000000000000000000000"
+	http              = flag.String("http", storehttp.DefaultAddress, "HTTP address")
+	wsReadBufSize     = flag.Int("wsreadbufsize", storehttp.DefaultWebSocketReadBufferSize, "Web socket read buffer size")
+	wsWriteBufSize    = flag.Int("wswritebufsize", storehttp.DefaultWebSocketWriteBufferSize, "Web socket write buffer size")
+	wsWriteChanSize   = flag.Int("wswritechansize", storehttp.DefaultWebSocketWriteChanSize, "Size of a web socket connection write channel")
+	wsWriteTimeout    = flag.Duration("wswritetimeout", storehttp.DefaultWebSocketWriteTimeout, "Timeout for a web socket write")
+	wsPongTimeout     = flag.Duration("wspongtimeout", storehttp.DefaultWebSocketPongTimeout, "Timeout for a web socket expected pong")
+	wsPingInterval    = flag.Duration("wspinginterval", storehttp.DefaultWebSocketPingInterval, "Interval between web socket pings")
+	wsMaxMsgSize      = flag.Int64("maxmsgsize", storehttp.DefaultWebSocketMaxMsgSize, "Maximum size of a received web socket message")
+	endpoint          = flag.String("endpoint", tmstore.DefaultEndpoint, "endpoint used to communicate with Tendermint Core")
+	tmWsRetryInterval = flag.Duration("tmWsRetryInterval", tmstore.DefaultWsRetryInterval, "interval between tendermint websocket connection tries")
+	certFile          = flag.String("tlscert", "", "TLS certificate file")
+	keyFile           = flag.String("tlskey", "", "TLS private key file")
+	version           = "0.1.0"
+	commit            = "00000000000000000000000000000000"
 )
 
 func main() {
@@ -45,6 +49,15 @@ func main() {
 	log.Infof("%s v%s@%s", tmstore.Description, version, commit[:7])
 
 	a := tmstore.New(&tmstore.Config{Endpoint: *endpoint, Version: version, Commit: commit})
+
+	go utils.Retry(func(attempt int) (retry bool, err error) {
+		err = a.StartWebsocket()
+		if err != nil {
+			log.Infof("%v, retrying...", err)
+			time.Sleep(*tmWsRetryInterval)
+		}
+		return true, err
+	}, 0)
 
 	httpConfig := &jsonhttp.Config{
 		Address:  *http,

--- a/tmstore/tmclient.go
+++ b/tmstore/tmclient.go
@@ -1,6 +1,8 @@
 package tmstore
 
 import (
+	"encoding/json"
+
 	"github.com/tendermint/go-rpc/client"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/types"
@@ -8,16 +10,18 @@ import (
 
 // TMClient is the type that implements the Tendermint RPC Client interface
 type TMClient struct {
-	remote   string
-	endpoint string
-	rpc      *rpcclient.ClientJSONRPC
+	remote     string
+	wsEndpoint string
+	rpc        *rpcclient.ClientJSONRPC
+	ws         *rpcclient.WSClient
 }
 
 // NewTMClient creates a new HTTPClient that communicates with Tendermint
 func NewTMClient(remote string) *TMClient {
 	return &TMClient{
-		rpc:    rpcclient.NewClientJSONRPC(remote),
-		remote: remote,
+		rpc:        rpcclient.NewClientJSONRPC(remote),
+		remote:     remote,
+		wsEndpoint: "/websocket",
 	}
 }
 
@@ -79,4 +83,46 @@ func (c *TMClient) broadcastTX(route string, tx types.Tx) (*ctypes.ResultBroadca
 		return nil, err
 	}
 	return (*tmResult).(*ctypes.ResultBroadcastTx), nil
+}
+
+/** websocket event stuff here... **/
+
+// StartWebsocket starts up a websocket and a listener goroutine
+// if already started, do nothing
+func (c *TMClient) StartWebsocket() error {
+	var err error
+	if c.ws == nil {
+		ws := rpcclient.NewWSClient(c.remote, c.wsEndpoint)
+		_, err = ws.Start()
+		if err == nil {
+			c.ws = ws
+		}
+	}
+	return err
+}
+
+// StopWebsocket stops the websocket connection
+func (c *TMClient) StopWebsocket() {
+	if c.ws != nil {
+		c.ws.Stop()
+		c.ws = nil
+	}
+}
+
+// GetEventChannels returns the results and error channel from the websocket
+func (c *TMClient) GetEventChannels() (chan json.RawMessage, chan error, chan struct{}) {
+	if c.ws == nil {
+		return nil, nil, nil
+	}
+	return c.ws.ResultsCh, c.ws.ErrorsCh, c.ws.Quit
+}
+
+// Subscribe to websocket channel
+func (c *TMClient) Subscribe(event string) error {
+	return c.ws.Subscribe(event)
+}
+
+// Unsubscribe from websocket channel
+func (c *TMClient) Unsubscribe(event string) error {
+	return c.ws.Unsubscribe(event)
 }

--- a/tmstore/tmstore_test.go
+++ b/tmstore/tmstore_test.go
@@ -27,9 +27,12 @@ func TestTMStore(t *testing.T) {
 			config := &Config{
 				Endpoint: GetConfig().GetString("rpc_laddr"),
 			}
-			return New(config), nil
+			s := New(config)
+			go s.StartWebsocket()
+			return s, nil
 		},
 		Free: func(s store.Adapter) {
+			s.(*TMStore).StopWebsocket()
 			Reset()
 		},
 	}.RunTests(t)

--- a/utils/retry.go
+++ b/utils/retry.go
@@ -1,0 +1,33 @@
+package utils
+
+import "errors"
+
+var errMaxRetriesReached = errors.New("exceeded retry limit")
+
+// Func represents functions that can be retried.
+type Func func(attempt int) (retry bool, err error)
+
+// Retry keeps trying the function until the second argument
+// returns false, or no error is returned.
+func Retry(fn Func, maxRetries int) error {
+	var err error
+	var cont bool
+	attempt := 1
+	for {
+		cont, err = fn(attempt)
+		if !cont || err == nil {
+			break
+		}
+		attempt++
+		if maxRetries > 0 && attempt > maxRetries {
+			return errMaxRetriesReached
+		}
+	}
+	return err
+}
+
+// IsMaxRetries checks whether the error is due to hitting the
+// maximum number of retries or not.
+func IsMaxRetries(err error) bool {
+	return err == errMaxRetriesReached
+}

--- a/utils/retry_test.go
+++ b/utils/retry_test.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+)
+
+const retriesExpected = 10
+
+func TestRetryWithError(t *testing.T) {
+	retriesCount := 0
+
+	err := Retry(func(attempt int) (bool, error) {
+		retriesCount++
+		return true, errors.New("error")
+	}, retriesExpected)
+
+	if !IsMaxRetries(err) {
+		t.Errorf("Retry(): expected error to be Max Retries was %v", err)
+	}
+
+	if got, want := retriesCount, retriesExpected; got != want {
+		t.Errorf("Retry(): expected %v retries, got %v", want, got)
+	}
+}
+
+func TestRetryWithoutError(t *testing.T) {
+	err := Retry(func(attempt int) (bool, error) {
+		if attempt == retriesExpected-1 {
+			return false, nil
+		}
+		return true, errors.New("error")
+	}, retriesExpected)
+
+	if err != nil {
+		t.Errorf("Retry(): expected no error, got %v", err)
+	}
+}


### PR DESCRIPTION
- didSaveChans must be notified when a new Block is received by the
  underlying Tendermint Application

- it cannot be done in the SaveSegment method (called only by the
  transaction maker) but it must leverage the Tendermint Core websocket endpoint